### PR TITLE
added Richmond, VA bail numbers

### DIFF
--- a/bail.html
+++ b/bail.html
@@ -98,10 +98,9 @@
 
 
 
-  <h2 id = states>Deleware</h2>
+  <h2 id = states>Delaware</h2>
   <div id = links>
       <p id = linky >Food Not Bombs Jail Support at (833)-362-9456</p>
-      <br>
       <p id = linky >The Delaware chapter of the National Lawyers Guild can be reached at delaware@nlg.org</p>
       <br>
     </div>
@@ -110,8 +109,8 @@
   <h2 id = states>Georgia</h2>
   <div id = links>
       <p id = linky>Atl Jail Support: Line couldn't be set up. Call 404-689-1519</p>
-      <br>
       <a id = linky href="https://twitter.com/ShippEsq/status/1266496256190406657?s=19" target = "_blank">Attorney willing to represent protesters pro bono in Atlanta, GA</a>
+      <br>
       <br>
 
     </div>
@@ -122,6 +121,7 @@
   <div id = links>
       <a id = linky href="https://twitter.com/DerrickMorgan91/status/1266701197932523520?s=19" target = "_blank">Attorney donating (pro bono) services to protesters arrested in Chicago, Indianapolis, or Louisville.</a>
       <br>
+      <br>
     </div>
 
 
@@ -131,6 +131,7 @@
   <div id = links>
       <a id = linky href="https://forms.gle/iqFcpdcZLJb86WMWA" target = "_blank">Black Bail Fund form for attorneys offering pro bono services</a>
       <br>
+      <br>
     </div>
 
 
@@ -138,6 +139,7 @@
   <h2 id = states>Missouri</h2>
   <div id = links>
       <a id = linky href="https://forms.gle/uPwdNMDqQ1n3vbas8" target = "_blank">MO Black Bail Relief Fund: Request Bail</a>
+      <br>
       <br>
     </div>
 
@@ -152,7 +154,7 @@
 
 
 
-  <h2 id = states>Oregan</h2>
+  <h2 id = states>Oregon</h2>
   <div id = links>
       <p id = linky>Jail support through the GDC at pdxgdc@riseup.net or by 503-442-0866</p>
       <br>
@@ -167,12 +169,21 @@
       <br>
       <a id = linky href="https://twitter.com/ericwsundin/status/1266550967253831680?s=19" target = "_blank">Attorney willing to represent protesters taken into custody in Houston, TX</a>
       <br>
+      <br>
     </div>
 
 
+      
+  <h2 id = states>Virginia</h2>
+  <div id = links>
+      <p id = linky>Richmond Community Bail Fund: 804-601-4944 (Use this number if you are NOT calling from within a Richmond City Jail)</p>
+      <p id = linky>Richmond Community Bail Fund: 804-291-8520 (Use this number if you are ARE calling from within a Richmond City Jail)</p>
+      <br>
+    </div>
+      
 
  
-  <h2 id = states>Washington D.C.</h2>
+  <h2 id = states>Washington, D.C.</h2>
   <div id = links>
       <a id = linky href="https://www.dccourts.gov/services/criminal-matters/posting-bond" target = "_blank">Posting Bonds in D.C.</a>
       <br>


### PR DESCRIPTION
added Richmond bail numbers, fixed typos, and fixed cosmetic spacing differences between <a> tags and <p> tags

Richmond bail information retrieved from: https://twitter.com/RVABailFund/status/1268979621728575489?s=20